### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This GitHub Action copies a folder from the current repository to a location in 
           uses: actions/checkout@v2
 
         - name: Create pull request
-          uses: paygoc6/action-pull-request-another-repo@v1.0.1
+          uses: paygoc6/action-pull-request-another-repo@v1.0.3
           env:
             API_TOKEN_GITHUB: ${{ secrets.API_TOKEN_GITHUB }}
           with:


### PR DESCRIPTION
I think pinning to a specific version is wise for relying parties.  But changing to `v1` would be more convenient for the maintainers to avoid having to bump this as part of each release.