### PR TITLE
fix: bump alpine version 3.14

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.13
+FROM alpine:3.14
 
 RUN apk update && \
     apk upgrade && \


### PR DESCRIPTION
The GO build fails in 3.13 due to Go version 1.15, bumping to 3.14 gives Go 1.16.

pkg/cmd/extension/manager.go:8:2: package io/fs is not in GOROOT (/usr/lib/go/src/io/fs)
  exit status 1
  build.go: building task `bin/gh` failed.